### PR TITLE
Cycles Endpoint

### DIFF
--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/Base.lproj/Main.storyboard
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/Base.lproj/Main.storyboard
@@ -312,7 +312,7 @@
                                         <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rFr-a9-8Js" id="mSU-nv-LVR">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43.666666666666664"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/Endpoints.plist
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/Endpoints.plist
@@ -10,6 +10,8 @@
 	<dict/>
 	<key>Get</key>
 	<dict>
+		<key>TestCycles</key>
+		<string>jamacloud.com/rest/latest/testplans/{planId}/testcycles</string>
 		<key>TestPlans</key>
 		<string>jamacloud.com/rest/latest/testplans?project={projectId}</string>
 		<key>Projects</key>

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/LoginViewController.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/LoginViewController.swift
@@ -28,11 +28,13 @@ class LoginViewController: UIViewController, UITextFieldDelegate {
         backItem.title = "Log Out"
         navigationItem.backBarButtonItem = backItem
     }
+    
     func setTextFieldDelegates() {
         self.userNameTextBox.delegate = self
         self.instanceTextBox.delegate = self
         self.passwordTextBox.delegate = self
     }
+    
     override func viewWillAppear(_ animated: Bool) {
         //Make sure that the password is not saved when the login page reappears.
         passwordTextBox.text = ""

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestCycleListModel.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestCycleListModel.swift
@@ -13,6 +13,9 @@ class TestCycleListModel {
     
     func extractCycleList(fromData: [[String : AnyObject]]) {
         for cycle in fromData {
+            if cycle["itemType"] as! Int != 36 {
+                break
+            }
             let tmpCycle = TestCycleModel()
             tmpCycle.extractCycle(fromData: cycle)
             testCycleList.append(tmpCycle)

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestCycleListModel.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestCycleListModel.swift
@@ -7,3 +7,15 @@
 //
 
 import Foundation
+
+class TestCycleListModel {
+    var testCycleList: [TestCycleModel] = []
+    
+    func extractCycleList(fromData: [[String : AnyObject]]) {
+        for cycle in fromData {
+            let tmpCycle = TestCycleModel()
+            tmpCycle.extractCycle(fromData: cycle)
+            testCycleList.append(tmpCycle)
+        }
+    }
+}

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestCycleModel.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestCycleModel.swift
@@ -7,3 +7,14 @@
 //
 
 import Foundation
+
+class TestCycleModel {
+    var id = -1
+    var name = ""
+    
+    func extractCycle(fromData: [String: AnyObject]) {
+        id = fromData["id"] as! Int
+        let fields: [String :  AnyObject] = fromData["fields"] as! Dictionary
+        name = fields["name"] as! String
+    }
+}

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestListViewController.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestListViewController.swift
@@ -49,13 +49,12 @@ class TestListViewController: UIViewController {
     
     // TO DO: attach this action to the selected plan button
     func getCyclesForPlanOnClick() {
-        // get plan id for chosen testplanmodel somehow
+        // TO DO: get plan id for chosen testplanmodel somehow
         planId = 3334
         
         self.currentTestLevel = .cycle
         let cycleEndpoint = buildTestCycleEndpointString()
         RestHelper.hitEndpoint(atEndpointString: cycleEndpoint, withDelegate: self, httpMethod: "Get", username: username, password: password)
-        print(cycleEndpoint)
     }
     
     func buildTestCycleEndpointString() -> String {
@@ -78,14 +77,12 @@ extension TestListViewController: EndpointDelegate {
             return
         }
         DispatchQueue.main.async {
-            
             switch self.currentTestLevel {
                 
                 case .plan:
                     let tmpList = TestPlanListModel()
                     tmpList.extractPlanList(fromData: unwrappedData)
                     self.testPlanList.testPlanList.append(contentsOf: tmpList.testPlanList)
-                    print("switched to plan")
                     //self.testPlanList.testPlanList.sort(by: self.comparePlans(lhs:rhs:))
             
                     //reload Data in view
@@ -99,7 +96,7 @@ extension TestListViewController: EndpointDelegate {
                     let tmpList = TestCycleListModel()
                     tmpList.extractCycleList(fromData: unwrappedData)
                     self.testCycleList.testCycleList.append(contentsOf: tmpList.testCycleList)
-                    print("switched to cycle")
+
                     //reload Data in view? self.testCycle.reloadData()
                 
                     //keep calling api while there are still more cycles
@@ -108,8 +105,7 @@ extension TestListViewController: EndpointDelegate {
                     }
                         
                 case .run:
-                    let _ = TestCycleListModel()
-                    //Add call for test runs here
+                    let _ = 0  //TO DO: Add call for test runs here and remove this line
 
             }
         }

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestPlanListModel.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestPlanListModel.swift
@@ -13,6 +13,9 @@ class TestPlanListModel {
     
     func extractPlanList(fromData: [[String : AnyObject]]) {
         for plan in fromData {
+            if plan["itemType"] as! Int != 35 {
+                break
+            }
             let tmpPlan = TestPlanModel()
             tmpPlan.extractPlan(fromData: plan)
             testPlanList.append(tmpPlan)

--- a/Mobile Test Runner for Jama/Mobile Test Runner for JamaTests/TestCycleListModelUnitTests.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for JamaTests/TestCycleListModelUnitTests.swift
@@ -21,6 +21,8 @@ class TestCycleListModelUnitTests: XCTestCase {
     var projectId = 123
     var cycle1Name = "cycle1"
     var cycle2Name = "cycle2"
+    var testCycleItemType = 36
+    var notTestCycleItemType = 37
     var data: [[String : AnyObject]] = []
     
     override func setUp() {
@@ -33,10 +35,12 @@ class TestCycleListModelUnitTests: XCTestCase {
         fields1.updateValue(cycle1Name as AnyObject, forKey: "name")
         cycle1Data.updateValue(id1 as AnyObject, forKey: "id")
         cycle1Data.updateValue(fields1 as AnyObject, forKey: "fields")
+        cycle1Data.updateValue(testCycleItemType as AnyObject, forKey: "itemType")
         
         fields2.updateValue(cycle2Name as AnyObject, forKey: "name")
         cycle2Data.updateValue(id2 as AnyObject, forKey: "id")
         cycle2Data.updateValue(fields2 as AnyObject, forKey: "fields")
+        cycle2Data.updateValue(testCycleItemType as AnyObject, forKey: "itemType")
         
         data.append(cycle1Data)
         data.append(cycle2Data)
@@ -60,5 +64,18 @@ class TestCycleListModelUnitTests: XCTestCase {
         XCTAssertEqual(cycle1.name, cycleList.testCycleList[0].name)
         XCTAssertEqual(cycle2.id, cycleList.testCycleList[1].id)
         XCTAssertEqual(cycle2.name, cycleList.testCycleList[1].name)
+    }
+    
+    func testExtractCycleListFromWrongItemTypeData() {
+        cycle1Data.updateValue(notTestCycleItemType as AnyObject, forKey: "itemType")
+        cycle2Data.updateValue(notTestCycleItemType as AnyObject, forKey: "itemType")
+        
+        data = []
+        data.append(cycle1Data)
+        data.append(cycle2Data)
+        
+        cycleList.extractCycleList(fromData: data)
+        
+        XCTAssertTrue(cycleList.testCycleList.isEmpty)
     }
 }

--- a/Mobile Test Runner for Jama/Mobile Test Runner for JamaTests/TestCycleListModelUnitTests.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for JamaTests/TestCycleListModelUnitTests.swift
@@ -7,16 +7,58 @@
 //
 
 import XCTest
-
+@testable import Mobile_Test_Runner_for_Jama
 class TestCycleListModelUnitTests: XCTestCase {
+    var cycleList = TestCycleListModel()
+    var cycle1 = TestCycleModel()
+    var cycle2 = TestCycleModel()
+    var fields1: [String : AnyObject] = [:]
+    var fields2: [String : AnyObject] = [:]
+    var cycle1Data: [String : AnyObject] = [:]
+    var cycle2Data: [String : AnyObject] = [:]
+    var id1 = 1
+    var id2 = 2
+    var projectId = 123
+    var cycle1Name = "cycle1"
+    var cycle2Name = "cycle2"
+    var data: [[String : AnyObject]] = []
     
     override func setUp() {
         super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        cycle1.id = id1
+        cycle2.id = id2
+        cycle1.name = cycle1Name
+        cycle2.name = cycle2Name
+        
+        fields1.updateValue(cycle1Name as AnyObject, forKey: "name")
+        cycle1Data.updateValue(id1 as AnyObject, forKey: "id")
+        cycle1Data.updateValue(fields1 as AnyObject, forKey: "fields")
+        
+        fields2.updateValue(cycle2Name as AnyObject, forKey: "name")
+        cycle2Data.updateValue(id2 as AnyObject, forKey: "id")
+        cycle2Data.updateValue(fields2 as AnyObject, forKey: "fields")
+        
+        data.append(cycle1Data)
+        data.append(cycle2Data)
     }
     
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
+    }
+    
+    func testExtractTestCycleFromEmptyData() {
+        cycleList.extractCycleList(fromData: [])
+        
+        XCTAssertTrue(cycleList.testCycleList.isEmpty)
+    }
+    
+    func testExtractCycleList() {
+        cycleList.extractCycleList(fromData: data)
+        
+        XCTAssertEqual(cycle1.id, cycleList.testCycleList[0].id)
+        XCTAssertEqual(cycle1.name, cycleList.testCycleList[0].name)
+        XCTAssertEqual(cycle2.id, cycleList.testCycleList[1].id)
+        XCTAssertEqual(cycle2.name, cycleList.testCycleList[1].name)
     }
 }

--- a/Mobile Test Runner for Jama/Mobile Test Runner for JamaTests/TestCycleModelUnitTests.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for JamaTests/TestCycleModelUnitTests.swift
@@ -7,16 +7,27 @@
 //
 
 import XCTest
-
+@testable import Mobile_Test_Runner_for_Jama
 class TestCycleModelUnitTests: XCTestCase {
-    
+    var data: [String: AnyObject] = [:]
+    var testCycle = TestCycleModel()
     override func setUp() {
         super.setUp()
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+        var fields: [String : AnyObject] = [:]
+        fields.updateValue("cycle1" as AnyObject, forKey: "name")
+        data.updateValue(2323 as AnyObject, forKey: "id")
+        data.updateValue(fields as AnyObject, forKey: "fields")
     }
     
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
+    }
+    
+    func testExtractPlanFromData() {
+        testCycle.extractCycle(fromData: data)
+        
+        XCTAssertEqual(2323, testCycle.id)
+        XCTAssertEqual("cycle1", testCycle.name)
     }
 }

--- a/Mobile Test Runner for Jama/Mobile Test Runner for JamaTests/TestListViewControllerUnitTests.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for JamaTests/TestListViewControllerUnitTests.swift
@@ -69,4 +69,32 @@ class TestListViewControllerUnitTests: XCTestCase {
         XCTAssertEqual(NSTextAlignment.center, cell.textLabel?.textAlignment)
         XCTAssertEqual(font, cell.textLabel?.font)
     }
+    
+    
+    func testCompareCycle() {
+        let plan1 = TestPlanModel()
+        let plan2 = TestPlanModel()
+        
+        plan1.name = "aaa"
+        plan2.name = "bbb"
+        XCTAssertTrue(viewController.comparePlans(lhs: plan1, rhs: plan2))
+        XCTAssertFalse(viewController.comparePlans(lhs: plan2, rhs: plan1))
+        XCTAssertFalse(viewController.comparePlans(lhs: plan1, rhs: plan1))
+        
+        plan1.name = "AAA"
+        XCTAssertTrue(viewController.comparePlans(lhs: plan1, rhs: plan2))
+        XCTAssertFalse(viewController.comparePlans(lhs: plan2, rhs: plan1))
+        XCTAssertFalse(viewController.comparePlans(lhs: plan1, rhs: plan1))
+        
+        plan1.name = "111"
+        XCTAssertTrue(viewController.comparePlans(lhs: plan1, rhs: plan2))
+        XCTAssertFalse(viewController.comparePlans(lhs: plan2, rhs: plan1))
+        XCTAssertFalse(viewController.comparePlans(lhs: plan1, rhs: plan1))
+        
+        plan2.name = "000"
+        XCTAssertTrue(viewController.comparePlans(lhs: plan2, rhs: plan1))
+        XCTAssertFalse(viewController.comparePlans(lhs: plan1, rhs: plan2))
+        XCTAssertFalse(viewController.comparePlans(lhs: plan1, rhs: plan1))
+        
+    }
 }

--- a/Mobile Test Runner for Jama/Mobile Test Runner for JamaTests/TestListViewControllerUnitTests.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for JamaTests/TestListViewControllerUnitTests.swift
@@ -69,32 +69,4 @@ class TestListViewControllerUnitTests: XCTestCase {
         XCTAssertEqual(NSTextAlignment.center, cell.textLabel?.textAlignment)
         XCTAssertEqual(font, cell.textLabel?.font)
     }
-    
-    
-    func testCompareCycle() {
-        let plan1 = TestPlanModel()
-        let plan2 = TestPlanModel()
-        
-        plan1.name = "aaa"
-        plan2.name = "bbb"
-        XCTAssertTrue(viewController.comparePlans(lhs: plan1, rhs: plan2))
-        XCTAssertFalse(viewController.comparePlans(lhs: plan2, rhs: plan1))
-        XCTAssertFalse(viewController.comparePlans(lhs: plan1, rhs: plan1))
-        
-        plan1.name = "AAA"
-        XCTAssertTrue(viewController.comparePlans(lhs: plan1, rhs: plan2))
-        XCTAssertFalse(viewController.comparePlans(lhs: plan2, rhs: plan1))
-        XCTAssertFalse(viewController.comparePlans(lhs: plan1, rhs: plan1))
-        
-        plan1.name = "111"
-        XCTAssertTrue(viewController.comparePlans(lhs: plan1, rhs: plan2))
-        XCTAssertFalse(viewController.comparePlans(lhs: plan2, rhs: plan1))
-        XCTAssertFalse(viewController.comparePlans(lhs: plan1, rhs: plan1))
-        
-        plan2.name = "000"
-        XCTAssertTrue(viewController.comparePlans(lhs: plan2, rhs: plan1))
-        XCTAssertFalse(viewController.comparePlans(lhs: plan1, rhs: plan2))
-        XCTAssertFalse(viewController.comparePlans(lhs: plan1, rhs: plan1))
-        
-    }
-}
+ }

--- a/Mobile Test Runner for Jama/Mobile Test Runner for JamaTests/TestPlanListModelUnitTests.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for JamaTests/TestPlanListModelUnitTests.swift
@@ -21,6 +21,8 @@ class TestPlanListModelUnitTests: XCTestCase {
     var projectId = 123
     var plan1Name = "plan1"
     var plan2Name = "plan2"
+    var testPlanType = 35
+    var notTestPlanType = 36
     var data: [[String : AnyObject]] = []
     
     override func setUp() {
@@ -36,11 +38,13 @@ class TestPlanListModelUnitTests: XCTestCase {
         plan1Data.updateValue(id1 as AnyObject, forKey: "id")
         plan1Data.updateValue(projectId as AnyObject, forKey: "project")
         plan1Data.updateValue(fields1 as AnyObject, forKey: "fields")
+        plan1Data.updateValue(testPlanType as AnyObject, forKey: "itemType")
         
         fields2.updateValue(plan2Name as AnyObject, forKey: "name")
         plan2Data.updateValue(id2 as AnyObject, forKey: "id")
         plan2Data.updateValue(projectId as AnyObject, forKey: "project")
         plan2Data.updateValue(fields2 as AnyObject, forKey: "fields")
+        plan2Data.updateValue(testPlanType as AnyObject, forKey: "itemType")
         
         data.append(plan1Data)
         data.append(plan2Data)
@@ -66,5 +70,16 @@ class TestPlanListModelUnitTests: XCTestCase {
         XCTAssertEqual(plan2.id, planList.testPlanList[1].id)
         XCTAssertEqual(plan2.projectId, planList.testPlanList[1].projectId)
         XCTAssertEqual(plan2.name, planList.testPlanList[1].name)
+    }
+    
+    func testExtractTestPlanFromWrongItemTypeData() {
+        plan1Data.updateValue(notTestPlanType as AnyObject, forKey: "itemType")
+        plan2Data.updateValue(notTestPlanType as AnyObject, forKey: "itemType")
+        
+        data = []
+        data.append(plan1Data)
+        data.append(plan2Data)
+        
+        XCTAssertTrue(planList.testPlanList.isEmpty)
     }
 }


### PR DESCRIPTION
Created the TestCycle and TestCycleList models. Added the test cycles endpoint to Endpoints.plist. Added a mostly complete function that will need to be called when the user clicks on a test plan (still need to find a way to set the chosen plan's ID based on which they click). Added functions to build the endpoint string and get data back using RestHelper. Adapted the main async function with a switch statement based on which API call is needed so RestHelper doesn't hate us. This could use a few more tests, but I will not have time to work on this again until Sunday night and wanted others to be able to build on this in the meantime.