### PR TITLE
added check to ensure cycle is still selected when loading in runs.

### DIFF
--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestListViewController.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestListViewController.swift
@@ -197,7 +197,7 @@ extension TestListViewController: EndpointDelegate {
                         return
                     }
                     //If there are no runs, display an empty run with the default value set to No Runs Found, made unclickable and with no number in the buildRunCell function below
-                    if self.testRunList.testRunList.isEmpty {
+                    if self.testRunList.testRunList.isEmpty && self.selectedTestCycleId != -1 {
                         let emptyRun = TestRunModel()
                         self.testRunList.testRunList.insert(emptyRun, at: 0)
                         self.testList.reloadData()
@@ -307,6 +307,7 @@ extension TestListViewController: UITableViewDelegate, UITableViewDataSource {
         if selectedCycleTableViewIndex == indexPath.row {
             selectedCycleTableViewIndex = largeNumber
             selectedCycleIndex = largeNumber
+            selectedTestCycleId = -1
             testRunList.testRunList = []
             (testList.cellForRow(at: indexPath) as! TestListTableViewCell).unselectCell()
             testList.reloadData()


### PR DESCRIPTION
I am no longer able to make the app crash. I am not sure if it is possible to get duplicated items if you click on a cycle a bunch fast enough, but I was not able to make that happen either.