### PR TITLE
Popup bug after camera

### DIFF
--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/Base.lproj/Main.storyboard
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0Cp-yS-FkN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="0Cp-yS-FkN">
     <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -166,7 +166,7 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No projects found. Please contact your administrator." textAlignment="center" lineBreakMode="wordWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="atM-JS-d50">
-                                <rect key="frame" x="26" y="534" width="362" height="90"/>
+                                <rect key="frame" x="26" y="534" width="362" height="89.666666666666629"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="atM-JS-d50" secondAttribute="height" multiplier="303:75" id="bVH-yU-4JV"/>
                                 </constraints>
@@ -317,7 +317,7 @@
                                         <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="rFr-a9-8Js" id="mSU-nv-LVR">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -325,7 +325,7 @@
                                         <rect key="frame" x="0.0" y="72" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="1mn-LC-0ox" id="q9h-Zr-M4H">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -333,7 +333,7 @@
                                         <rect key="frame" x="0.0" y="116" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="B1E-R0-Lnn" id="acE-da-uOf">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -436,10 +436,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="114-Ve-vhn" userLabel="ButtonView">
-                                <rect key="frame" x="0.0" y="589" width="414" height="103"/>
+                                <rect key="frame" x="0.0" y="588.66666666666652" width="414" height="103.33333333333337"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JXM-kY-Oc6">
-                                        <rect key="frame" x="47" y="5" width="94" height="93"/>
+                                        <rect key="frame" x="47.333333333333343" y="5" width="93.333333333333314" height="93.333333333333371"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="JXM-kY-Oc6" secondAttribute="height" multiplier="1:1" id="792-w9-TIV"/>
                                         </constraints>
@@ -451,7 +451,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="tnj-KD-mnB" userLabel="Input Button">
-                                        <rect key="frame" x="161" y="5" width="93" height="93"/>
+                                        <rect key="frame" x="160.66666666666666" y="5" width="93.666666666666686" height="93.333333333333371"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="tnj-KD-mnB" secondAttribute="height" multiplier="1:1" id="7Ae-sJ-iez"/>
                                         </constraints>
@@ -463,7 +463,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="kRQ-iu-ksj">
-                                        <rect key="frame" x="274" y="5" width="94" height="93"/>
+                                        <rect key="frame" x="274.33333333333331" y="5" width="93.333333333333371" height="93.333333333333371"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="kRQ-iu-ksj" secondAttribute="height" multiplier="1:1" id="apf-bv-9dO"/>
                                         </constraints>
@@ -490,14 +490,14 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FSP-Eo-Vq8" userLabel="Bottom Divider">
-                                <rect key="frame" x="0.0" y="579" width="414" height="10"/>
+                                <rect key="frame" x="0.0" y="578.66666666666663" width="414" height="10"/>
                                 <color key="backgroundColor" red="0.94509803920000002" green="0.3803921569" blue="0.1647058824" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="10" id="iWn-SL-8jU"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kWW-gk-dOH" userLabel="ContentView">
-                                <rect key="frame" x="0.0" y="64" width="414" height="515"/>
+                                <rect key="frame" x="0.0" y="64" width="414" height="514.66666666666663"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Q1e-iC-eME">
                                         <rect key="frame" x="0.0" y="50" width="414" height="43"/>
@@ -741,7 +741,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="7gT-7g-SHk">
-                                <rect key="frame" x="0.0" y="114" width="414" height="465"/>
+                                <rect key="frame" x="0.0" y="114" width="414" height="464.66666666666663"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <prototypes>
@@ -749,7 +749,7 @@
                                         <rect key="frame" x="0.0" y="28" width="414" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="k0v-dr-JEK" id="2iW-Ca-kqn" customClass="TestStepTableViewCell" customModule="Mobile_Test_Runner_for_Jama" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="0.0" width="381" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="381" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </tableViewCellContentView>
                                     </tableViewCell>
@@ -760,16 +760,16 @@
                                 </connections>
                             </tableView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xDR-j2-5vA">
-                                <rect key="frame" x="0.0" y="114" width="414" height="465"/>
+                                <rect key="frame" x="0.0" y="114" width="414" height="464.66666666666663"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="LVu-gK-Vj5">
-                                        <rect key="frame" x="0.0" y="46" width="414" height="372"/>
+                                        <rect key="frame" x="0.0" y="46" width="414" height="371.66666666666663"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Hbu-th-o48" userLabel="Status label view">
-                                                <rect key="frame" x="0.0" y="304" width="414" height="60"/>
+                                                <rect key="frame" x="0.0" y="303.66666666666663" width="414" height="59.999999999999943"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Test Run Status: " textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nRI-nh-DFo">
-                                                        <rect key="frame" x="132" y="8" width="151" height="55"/>
+                                                        <rect key="frame" x="132" y="8" width="151" height="54.999999999999943"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="55" id="1nX-Xi-CJt"/>
                                                         </constraints>
@@ -804,7 +804,7 @@
                                                 <nil key="highlightedColor"/>
                                             </label>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jl7-Qg-0zm">
-                                                <rect key="frame" x="213" y="128" width="116" height="116"/>
+                                                <rect key="frame" x="213" y="127.66666666666669" width="116" height="116"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="jl7-Qg-0zm" secondAttribute="height" multiplier="1:1" id="Wij-kg-7ht"/>
                                                 </constraints>
@@ -816,13 +816,13 @@
                                                 </connections>
                                             </button>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="W8B-bg-BAg" userLabel="Central button divider">
-                                                <rect key="frame" x="206" y="128" width="2" height="116"/>
+                                                <rect key="frame" x="206" y="127.66666666666669" width="2" height="116"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="2" id="Bj4-UF-aVQ"/>
                                                 </constraints>
                                             </view>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ms8-Um-3Wt">
-                                                <rect key="frame" x="85" y="128" width="116" height="116"/>
+                                                <rect key="frame" x="85" y="127.66666666666669" width="116" height="116"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" secondItem="ms8-Um-3Wt" secondAttribute="height" multiplier="1:1" id="jB8-rU-WYP"/>
                                                 </constraints>
@@ -866,10 +866,10 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="eQ6-Hy-uXH" userLabel="ButtonView">
-                                <rect key="frame" x="0.0" y="589" width="414" height="103"/>
+                                <rect key="frame" x="0.0" y="588.66666666666652" width="414" height="103.33333333333337"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="miI-Kx-Bj4" userLabel="Submit Button">
-                                        <rect key="frame" x="13" y="5" width="94" height="93"/>
+                                        <rect key="frame" x="13" y="5" width="93.666666666666671" height="93.333333333333371"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="miI-Kx-Bj4" secondAttribute="height" multiplier="1:1" id="RKC-Ur-WxC"/>
                                         </constraints>
@@ -881,7 +881,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rM3-gm-dNb" userLabel="Input Button">
-                                        <rect key="frame" x="112" y="5" width="93" height="93"/>
+                                        <rect key="frame" x="111.66666666666669" y="5" width="93.333333333333314" height="93.333333333333371"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="rM3-gm-dNb" secondAttribute="height" multiplier="1:1" id="hlU-c3-nGY"/>
                                         </constraints>
@@ -893,7 +893,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleAspectFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="B8F-ke-ULJ">
-                                        <rect key="frame" x="210" y="5" width="93" height="93"/>
+                                        <rect key="frame" x="209.99999999999997" y="5" width="93.333333333333286" height="93.333333333333371"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="B8F-ke-ULJ" secondAttribute="height" multiplier="1:1" id="QXS-I5-X1j"/>
                                         </constraints>
@@ -905,13 +905,13 @@
                                         </connections>
                                     </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="OqV-Yp-Ugw" userLabel="ButtonViewCenterView">
-                                        <rect key="frame" x="207" y="0.0" width="1" height="103"/>
+                                        <rect key="frame" x="207" y="0.0" width="1" height="103.33333333333337"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="1" id="HQ0-cc-Ktn"/>
                                         </constraints>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H4x-hE-VAl" userLabel="Photo Button">
-                                        <rect key="frame" x="308" y="5" width="94" height="93"/>
+                                        <rect key="frame" x="308.33333333333326" y="5" width="93.666666666666686" height="93.333333333333371"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="H4x-hE-VAl" secondAttribute="height" multiplier="1:1" id="Sw6-nF-1vX"/>
                                         </constraints>
@@ -958,11 +958,53 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1ZF-DZ-CxQ" userLabel="Bottom Divider">
-                                <rect key="frame" x="0.0" y="579" width="414" height="10"/>
+                                <rect key="frame" x="0.0" y="578.66666666666663" width="414" height="10"/>
                                 <color key="backgroundColor" red="0.94509803920000002" green="0.3803921569" blue="0.1647058824" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="10" id="MwH-Qv-7ZC"/>
                                 </constraints>
+                            </view>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="If4-uU-tGx" userLabel="CurrentPhotoView">
+                                <rect key="frame" x="0.0" y="114" width="414" height="464.66666666666663"/>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Kcs-gY-fjG">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="464.66666666666663"/>
+                                    </imageView>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="grL-y8-Kem" userLabel="Close">
+                                        <rect key="frame" x="361" y="1" width="52" height="52"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="grL-y8-Kem" secondAttribute="height" multiplier="1:1" id="kLD-NO-G3o"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="38"/>
+                                        <state key="normal" title="X">
+                                            <color key="titleColor" red="0.94509803920000002" green="0.3803921569" blue="0.1647058824" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                        </state>
+                                        <connections>
+                                            <action selector="closeAttachedImageView:" destination="NKr-0k-Apa" eventType="touchUpInside" id="dPd-kk-jbY"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <constraints>
+                                    <constraint firstItem="Kcs-gY-fjG" firstAttribute="width" secondItem="If4-uU-tGx" secondAttribute="width" id="2iZ-ac-jdc"/>
+                                    <constraint firstItem="Kcs-gY-fjG" firstAttribute="height" secondItem="If4-uU-tGx" secondAttribute="height" id="368-r0-vV9"/>
+                                    <constraint firstItem="grL-y8-Kem" firstAttribute="top" secondItem="If4-uU-tGx" secondAttribute="top" constant="1" id="3NA-i8-is7"/>
+                                    <constraint firstAttribute="trailing" secondItem="grL-y8-Kem" secondAttribute="trailing" constant="1" id="6dp-U2-gm8"/>
+                                    <constraint firstItem="Kcs-gY-fjG" firstAttribute="centerY" secondItem="If4-uU-tGx" secondAttribute="centerY" id="7Ca-ns-BPv"/>
+                                    <constraint firstItem="Kcs-gY-fjG" firstAttribute="centerX" secondItem="If4-uU-tGx" secondAttribute="centerX" id="b5b-9p-o1o"/>
+                                    <constraint firstItem="grL-y8-Kem" firstAttribute="width" secondItem="If4-uU-tGx" secondAttribute="width" multiplier="1:8" id="o5x-6m-WCd"/>
+                                </constraints>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                        <integer key="value" value="15"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="layer.borderColor">
+                                        <color key="value" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
+                                        <integer key="value" value="2"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                             </view>
                             <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="w7O-Ml-k6v" userLabel="Popup Background View">
                                 <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
@@ -1008,48 +1050,6 @@
                                     <constraint firstItem="qgE-cu-Qsn" firstAttribute="height" secondItem="eJc-4V-jEK" secondAttribute="height" multiplier="1:5" id="YRt-rC-U6j"/>
                                     <constraint firstItem="qgE-cu-Qsn" firstAttribute="width" secondItem="eJc-4V-jEK" secondAttribute="width" id="adk-qB-yCB"/>
                                     <constraint firstAttribute="bottom" secondItem="qgE-cu-Qsn" secondAttribute="bottom" id="d1z-UE-qzj"/>
-                                </constraints>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                        <integer key="value" value="15"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="layer.borderColor">
-                                        <color key="value" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
-                                        <integer key="value" value="2"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="If4-uU-tGx" userLabel="CurrentPhotoView">
-                                <rect key="frame" x="0.0" y="114" width="414" height="465"/>
-                                <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Kcs-gY-fjG">
-                                        <rect key="frame" x="0.0" y="0.0" width="414" height="465"/>
-                                    </imageView>
-                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="grL-y8-Kem" userLabel="Close">
-                                        <rect key="frame" x="361" y="1" width="52" height="52"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="grL-y8-Kem" secondAttribute="height" multiplier="1:1" id="kLD-NO-G3o"/>
-                                        </constraints>
-                                        <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="38"/>
-                                        <state key="normal" title="X">
-                                            <color key="titleColor" red="0.94509803920000002" green="0.3803921569" blue="0.1647058824" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                        </state>
-                                        <connections>
-                                            <action selector="closeAttachedImageView:" destination="NKr-0k-Apa" eventType="touchUpInside" id="dPd-kk-jbY"/>
-                                        </connections>
-                                    </button>
-                                </subviews>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                <constraints>
-                                    <constraint firstItem="Kcs-gY-fjG" firstAttribute="width" secondItem="If4-uU-tGx" secondAttribute="width" id="2iZ-ac-jdc"/>
-                                    <constraint firstItem="Kcs-gY-fjG" firstAttribute="height" secondItem="If4-uU-tGx" secondAttribute="height" id="368-r0-vV9"/>
-                                    <constraint firstItem="grL-y8-Kem" firstAttribute="top" secondItem="If4-uU-tGx" secondAttribute="top" constant="1" id="3NA-i8-is7"/>
-                                    <constraint firstAttribute="trailing" secondItem="grL-y8-Kem" secondAttribute="trailing" constant="1" id="6dp-U2-gm8"/>
-                                    <constraint firstItem="Kcs-gY-fjG" firstAttribute="centerY" secondItem="If4-uU-tGx" secondAttribute="centerY" id="7Ca-ns-BPv"/>
-                                    <constraint firstItem="Kcs-gY-fjG" firstAttribute="centerX" secondItem="If4-uU-tGx" secondAttribute="centerX" id="b5b-9p-o1o"/>
-                                    <constraint firstItem="grL-y8-Kem" firstAttribute="width" secondItem="If4-uU-tGx" secondAttribute="width" multiplier="1:8" id="o5x-6m-WCd"/>
                                 </constraints>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/Base.lproj/Main.storyboard
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/Base.lproj/Main.storyboard
@@ -708,6 +708,7 @@
                         <outlet property="actionTextView" destination="j7z-pb-nHp" id="fSy-Oz-74S"/>
                         <outlet property="actionTextViewHeightContraint" destination="eQP-yN-0y4" id="jc3-lq-h2Y"/>
                         <outlet property="addResultsButton" destination="tnj-KD-mnB" id="dnf-qi-f3W"/>
+                        <outlet property="clearStepButton" destination="HoQ-oq-Dy8" id="f8L-DG-rZb"/>
                         <outlet property="expectedResultButton" destination="dcP-7h-pXF" id="xID-Na-T2U"/>
                         <outlet property="expectedResultsTextView" destination="8ZR-DR-O4d" id="9vY-gp-9EH"/>
                         <outlet property="expectedResultsTextViewHeightConstraint" destination="bYk-v3-2xJ" id="VJQ-iT-kkC"/>

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestRunIndexViewController.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestRunIndexViewController.swift
@@ -245,8 +245,6 @@ class TestRunIndexViewController: UIViewController, UITextViewDelegate {
         inputResultsBackground.isHidden = false
         inputResultsBox.isHidden = false
         popupOriginY = self.inputResultsBox.frame.origin.y
-        self.navigationController?.view.addSubview(inputResultsBackground)
-        self.navigationController?.view.addSubview(inputResultsBox)
     }
     
     //Called when 'Done' button in popup is clicked
@@ -275,9 +273,8 @@ class TestRunIndexViewController: UIViewController, UITextViewDelegate {
         }
     }
     
-    func textViewShouldReturn(_ textView: UITextView) -> Bool {
+    func textViewDidEndEditing(_ textView: UITextView) {
         inputResultsTextBox.resignFirstResponder()
-        return (true)
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestRunIndexViewController.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestRunIndexViewController.swift
@@ -245,6 +245,7 @@ class TestRunIndexViewController: UIViewController, UITextViewDelegate {
         inputResultsBackground.isHidden = false
         inputResultsBox.isHidden = false
         popupOriginY = self.inputResultsBox.frame.origin.y
+        self.cancelRun.isEnabled = false
     }
     
     //Called when 'Done' button in popup is clicked
@@ -255,6 +256,7 @@ class TestRunIndexViewController: UIViewController, UITextViewDelegate {
             testRun.result = inputResultsTextBox.text
         }
         setPlaceholderText()
+        self.cancelRun.isEnabled = true
         inputResultsTextBox.resignFirstResponder()
     }
     

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestStepViewController.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestStepViewController.swift
@@ -29,6 +29,7 @@ class TestStepViewController: UIViewController, UITextViewDelegate {
     @IBOutlet weak var notesButton: UIButton!
     @IBOutlet weak var titleDivider: UIView!
     @IBOutlet weak var runNameLabel: UILabel!
+    @IBOutlet weak var clearStepButton: UIBarButtonItem!
  
     var action = ""
     var expResult = ""
@@ -73,8 +74,8 @@ class TestStepViewController: UIViewController, UITextViewDelegate {
         inputResultsBackground.isHidden = false
         inputResultsBox.isHidden = false
         popupOriginY = self.inputResultsBox.frame.origin.y
-        self.navigationController?.view.addSubview(inputResultsBackground)
-        self.navigationController?.view.addSubview(inputResultsBox)
+        self.navigationItem.hidesBackButton = true
+        self.clearStepButton.isEnabled = false
     }
     
     @IBAction func didTapFail(_ sender: Any) {
@@ -185,6 +186,8 @@ class TestStepViewController: UIViewController, UITextViewDelegate {
         }
         setPlaceholderText()
         inputResultsTextBox.resignFirstResponder()
+        self.navigationItem.hidesBackButton = false
+        self.clearStepButton.isEnabled = true
     }
     
     // Move popup when keyboard appears/hides

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestStepViewController.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestStepViewController.swift
@@ -202,9 +202,8 @@ class TestStepViewController: UIViewController, UITextViewDelegate {
         }
     }
     
-    func textViewShouldReturn(_ textView: UITextView) -> Bool {
+    func textViewDidEndEditing(_ textView: UITextView) {
         inputResultsTextBox.resignFirstResponder()
-        return (true)
     }
     
     func textViewDidBeginEditing(_ textView: UITextView) {


### PR DESCRIPTION
Issue: After using camera, popup box would lose size/position constraints and get stuck.

In order to cover the navigation bar with the transparent black background, the popup view was originally added as a subview to the top navigation bar. Something about how the built-in camera code switches between its own views seems to be interfering with how the navigation controller handles having the popup as a subview.

Solution: Since there isn't time to completely rewrite the popup (to be its own view and have a delegate pass the results text between all the screens), the best compromise I found was to not have the transparent background continue over the navigation bar and instead just hide or disable the top navigation buttons while the popup is active.