### PR TITLE
Updated license error

### DIFF
--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/RestHelper.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/RestHelper.swift
@@ -276,19 +276,23 @@ class RestHelper {
     static func parseLocationFromNewAttachmentData(data: Data) -> Int {
         var id = -1
         do {
-        guard let jsonData = try JSONSerialization.jsonObject(with: data, options: [])
-            as? [String: Any] else {
+            guard let jsonData = try JSONSerialization.jsonObject(with: data, options: [])
+                as? [String: Any] else {
                 print("error trying to convert to JSON")
                 return 0
-        }
+            }
         //Retrieve the location string from the returned meta data and parse the new attachment id
-        let meta: [String:AnyObject] = jsonData["meta"] as! Dictionary
-        let location = meta["location"] as! String
-        let idStr = location.components(separatedBy: "attachments/").last
-        id = Int.init(idStr!)!
-        } catch {
-            print("error trying to convert to json")
-            return 0
+            let meta: [String:AnyObject] = jsonData["meta"] as! Dictionary
+        
+            if meta["status"] as! String == "Unauthorized" {
+                return -1
+            }
+            let location = meta["location"] as! String
+            let idStr = location.components(separatedBy: "attachments/").last
+            id = Int.init(idStr!)!
+            } catch {
+                print("error trying to convert to json")
+                return 0
         }
         return id
     }

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestRunIndexViewController.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestRunIndexViewController.swift
@@ -485,8 +485,9 @@ extension TestRunIndexViewController: AttachmentApiEndpointDelegate {
     //Once the API returns with the newly created "empty" attachment, call the upload image endpoint with the attachment id.
     func didCreateEmptyAttachment(withId: Int) {
         attachmentId = withId
+        //If the user was unauthorized to edit items, withId will be -1
         if withId == -1 {
-            let licenseErrorAlert = UIAlertController(title: "License error", message: "Editing items in Jama requires a creator license. Please contact your Jama administrator about your license needs. This test run will be submitted without an attachment.", preferredStyle: UIAlertControllerStyle.alert)
+            let licenseErrorAlert = UIAlertController(title: "License error", message: "Your license does not permit you to add attachments in Jama.  Please contact your Jama administrator about your license needs.", preferredStyle: UIAlertControllerStyle.alert)
             licenseErrorAlert.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: {
                 (action: UIAlertAction!) in
                 RestHelper.hitPutEndpoint(atEndpointString: self.buildTestRunPutEndpointString(), withDelegate: self, username: self.username, password: self.password, httpBodyData: self.buildPutRunBody())

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestRunIndexViewController.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestRunIndexViewController.swift
@@ -487,7 +487,7 @@ extension TestRunIndexViewController: AttachmentApiEndpointDelegate {
         attachmentId = withId
         //If the user was unauthorized to edit items, withId will be -1
         if withId == -1 {
-            let licenseErrorAlert = UIAlertController(title: "License error", message: "Your license does not permit you to add attachments in Jama.  Please contact your Jama administrator about your license needs.", preferredStyle: UIAlertControllerStyle.alert)
+            let licenseErrorAlert = UIAlertController(title: "License error", message: "You do not currently have the ability to add attachments to this project. Please contact your administrator.", preferredStyle: UIAlertControllerStyle.alert)
             licenseErrorAlert.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: {
                 (action: UIAlertAction!) in
                 RestHelper.hitPutEndpoint(atEndpointString: self.buildTestRunPutEndpointString(), withDelegate: self, username: self.username, password: self.password, httpBodyData: self.buildPutRunBody())

--- a/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestRunIndexViewController.swift
+++ b/Mobile Test Runner for Jama/Mobile Test Runner for Jama/TestRunIndexViewController.swift
@@ -90,6 +90,7 @@ class TestRunIndexViewController: UIViewController, UITextViewDelegate {
         noStepPassButton.setImage(notSelectedPassButtonImage, for: .normal)
         noStepFailButton.setImage(notSelectedFailButtonImage, for: .normal)
         photoToAttach = nil
+        photoToAttach = UIImage(named: "PASS.png")
         //Setup the close current image view button
         closeImageViewButton.setTitleColor(orangeColor, for: .normal)
         closeImageViewButton.layer.borderColor = lightGrayColor.cgColor
@@ -484,6 +485,17 @@ extension TestRunIndexViewController: AttachmentApiEndpointDelegate {
     //Once the API returns with the newly created "empty" attachment, call the upload image endpoint with the attachment id.
     func didCreateEmptyAttachment(withId: Int) {
         attachmentId = withId
+        if withId == -1 {
+            let licenseErrorAlert = UIAlertController(title: "License error", message: "Editing items in Jama requires a creator license. Please contact your Jama administrator about your license needs. This test run will be submitted without an attachment.", preferredStyle: UIAlertControllerStyle.alert)
+            licenseErrorAlert.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: {
+                (action: UIAlertAction!) in
+                RestHelper.hitPutEndpoint(atEndpointString: self.buildTestRunPutEndpointString(), withDelegate: self, username: self.username, password: self.password, httpBodyData: self.buildPutRunBody())
+            }))
+            DispatchQueue.main.async {
+                self.present(licenseErrorAlert, animated: true, completion: nil)
+            }
+        return
+        }
         let endpoint = buildAttachmentFileEndpointString(attachmentId: withId)
         RestHelper.putImageToAttachmentFile(atEndpointString: endpoint, image: photoToAttach!, withDelegate: self, username: username, password: password, runName: testRun.name)
     }
@@ -524,17 +536,6 @@ extension TestRunIndexViewController: AttachmentApiEndpointDelegate {
 extension TestRunIndexViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
     //Call action sheet where user can take new photo, view current photo or delete photo
     @IBAction func photoButton(_ sender: Any) {
-        //If the user does not have a Named type license then they cannot create attachments. Inform the user.
-        if currentUser.licenseType != "NAMED" {
-            let licenseErrorAlert = UIAlertController(title: "License error", message: "Editing items in Jama requires a creator license. Please contact your Jama administrator about your license needs.", preferredStyle: UIAlertControllerStyle.alert)
-            licenseErrorAlert.addAction(UIAlertAction(title: "Dismiss", style: .default, handler: {
-                (action: UIAlertAction!) in
-            }))
-            DispatchQueue.main.async {
-                self.present(licenseErrorAlert, animated: true, completion: nil)
-            }
-            return
-        }
         let photoOptions = UIAlertController(title: nil, message: "Add, retake, or remove a photo", preferredStyle: .actionSheet)
             
         let useCamera = UIAlertAction(title: "Take Photo", style: .default, handler:


### PR DESCRIPTION
This branch is the last bit of functionality from the Capstone team. We did not have quite enough time to make sure we had it fully tested so we did not want to merge it and potentially introduce bugs.

This branch changes the way that we handle user license errors. Currently we are checking the user's license type and if it is not the expected type we don't let the user type to upload a photo. With this branch the user is able to try to upload a photo (submits a run), regardless of license type, and if the server responds with an Unauthorized error the user receives the license error. The test run is submitted regardless.